### PR TITLE
wg-quick: Android: Use ip link to set MTU

### DIFF
--- a/src/wg-quick/android.c
+++ b/src/wg-quick/android.c
@@ -995,7 +995,7 @@ static void set_mtu(const char *iface, unsigned int mtu)
 	int endpoint_mtu, next_mtu;
 
 	if (mtu) {
-		cndc("interface setmtu %s %u", iface, mtu);
+		cmd("ip link set dev %s mtu %d", iface, mtu);
 		return;
 	}
 
@@ -1016,7 +1016,7 @@ static void set_mtu(const char *iface, unsigned int mtu)
 			endpoint_mtu = next_mtu;
 	}
 
-	cndc("interface setmtu %s %d", iface, endpoint_mtu - 80);
+	cmd("ip link set dev %s mtu %d", iface, endpoint_mtu - 80);
 }
 
 static void add_route(const char *iface, unsigned int netid, const char *route)


### PR DESCRIPTION
Signed-off-by: Adam Irr <adam.irr@outlook.com>

----

The ndc command used didn't work on my Nvidia Shield (rooted with a custom-built kernel). The ip link command does work. I have only tested this on an Nvidia Shield (Android TV - Version 9.0 Pie).

I couldn't find a lot of documentation on ndc so its possible my device/kernel is mis-configured. If you suspect this is the case, let me know.