### PR TITLE
FIX BUGS which may cause trap leading to " wg-quick up wg0 " failure on MACOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2015-2020 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
 
 PKG_CONFIG ?= pkg-config
-PREFIX ?= /usr
+PREFIX ?= /usr/local
 DESTDIR ?=
 SYSCONFDIR ?= /etc
 BINDIR ?= $(PREFIX)/bin

--- a/src/wg-quick/darwin.bash
+++ b/src/wg-quick/darwin.bash
@@ -230,7 +230,8 @@ collect_new_service_dns() {
 		get_response="$(cmd networksetup -getsearchdomains "$service")"
 		[[ $get_response == *" "* ]] && get_response="Empty"
 		[[ -n $get_response ]] && SERVICE_DNS_SEARCH["$service"]="$get_response"
-	done; } < <(networksetup -listallnetworkservices)
+	done; } < <(echo "Wi-Fi")
+	#done; } < <(networksetup -listallnetworkservices)
 
 	for service in "${!SERVICE_DNS[@]}"; do
 		if ! [[ -n ${found_services["$service"]} ]]; then


### PR DESCRIPTION
CLIENT: MACOS Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64
SERVER: ALGO on VLUTR
RAW(zsh) :
```
 > sudo wg-quick up wg0
Warning: `/private/etc/wireguard/wg0.conf' is world accessible
[#] wireguard-go utun
[+] Interface for wg0 is utun3
[#] wg setconf utun3 /dev/fd/63
[#] ifconfig utun3 inet 10.49.0.3 10.49.0.3 alias
[#] ifconfig utun3 inet6 2001:db8:a160::3 alias
[#] ifconfig utun3 up
[#] route -q -n add -inet6 ::/1 -interface utun3
[#] route -q -n add -inet6 8000::/1 -interface utun3
[#] route -q -n add -inet 0.0.0.0/1 -interface utun3
[#] route -q -n add -inet 128.0.0.0/1 -interface utun3
[#] route -q -n add -inet xxxxxxxx -gateway xxxxxxx
[#] networksetup -getdnsservers Wi-Fi
[#] networksetup -getsearchdomains Wi-Fi
[#] networksetup -getdnsservers Thunderbolt Bridge
[#] networksetup -getsearchdomains Thunderbolt Bridge
[#] networksetup -getdnsservers Bluetooth PAN
[#] networksetup -getsearchdomains Bluetooth PAN
[#] networksetup -setdnsservers Bluetooth PAN xxxx
[#] networksetup -setsearchdomains Bluetooth PAN Empty
[#] networksetup -setdnsservers Wi-Fi xxxxxx
[#] networksetup -setsearchdomains Wi-Fi Empty
[#] networksetup -setdnsservers Thunderbolt Bridge xxxxxx
[#] networksetup -setsearchdomains Thunderbolt Bridge Empty
[#] rm -f /var/run/wireguard/utun3.sock
[#] rm -f /var/run/wireguard/wg0.name
[#] route -q -n delete -inet xxxxxxx
```
locate darwin.bash line 233:"networksetup -listallnetworkservices" 
the comman may output like this :
```
> networksetup -listallnetworkservices
An asterisk (*) denotes that a network service is disabled.
Wi-Fi
*Thunderbolt Bridge
Bluetooth PAN
```

but the later two contains " " may cause Error like this:

```
> networksetup -getdnsservers Thunderbolt Bridge
Thunderbolt is not a recognized network service.
** Error: The parameters were not valid.
```
I simply fix it and modify the Makefile ( I think installing in /usr/local/bin is better than /usr/bin)
