### PR TITLE
Fix wg-quick gateway collection on darwin

### DIFF
--- a/src/wg-quick/darwin.bash
+++ b/src/wg-quick/darwin.bash
@@ -194,14 +194,14 @@ collect_gateways() {
 
 	GATEWAY4=""
 	while read -r destination gateway _; do
-		[[ $destination == default ]] || continue
+		[[ $destination == default && $gateway != "link#"* ]] || continue
 		GATEWAY4="$gateway"
 		break
 	done < <(netstat -nr -f inet)
 
 	GATEWAY6=""
 	while read -r destination gateway _; do
-		[[ $destination == default ]] || continue
+		[[ $destination == default && $gateway != "link#"* ]] || continue
 		GATEWAY6="$gateway"
 		break
 	done < <(netstat -nr -f inet6)


### PR DESCRIPTION
On macOS, under specific configurations, the `netstat -nr -f inet` and `netstat -nr -f inet6` outputs can look like this:

```
Routing tables

Internet:
Destination        Gateway            Flags        Netif Expire
0/1                utun0              UScg         utun0
default            link#25            UCSIg        utun0
```

This breaks the collection of the gateways (tries to execute `route -q -n add -inet 192.0.2.1 -gateway link#25`, which obviously fails as `link#25` is not a valid gateway)

This PR fixes that issue.