### PR TITLE
wg-quick@.service: Add deps on wg-quick.target

### DIFF
--- a/src/systemd/wg-quick@.service
+++ b/src/systemd/wg-quick@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=WireGuard via wg-quick(8) for %I
+Before=wg-quick.target
 After=network-online.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
 PartOf=wg-quick.target
@@ -19,4 +20,4 @@ ExecReload=/bin/bash -c 'exec /usr/bin/wg syncconf %i <(exec /usr/bin/wg-quick s
 Environment=WG_ENDPOINT_RESOLUTION_RETRIES=infinity
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target wg-quick.target


### PR DESCRIPTION
These dependencies ensure that instances of this service are started before wg-quick.target is considered started, allowing other services to depend on wg-quick.target to mean "all wg-quick services are started".