### PR TITLE
Update Rust dependencies to fix snow vulnerability CWE-440

### DIFF
--- a/contrib/external-tests/rust/Cargo.toml
+++ b/contrib/external-tests/rust/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["jason@zx2c4.com", "me@jake.su"]
 publish = false
 
 [dependencies]
-snow = "^0.1.0-preview"
+snow = "^0.9.6"
 base64 = "^0.5"
 rust-crypto = "*"
 byteorder = "*"


### PR DESCRIPTION
Due to a security weakness in "snow".  [(CWE-440)](https://github.com/mcginty/snow/security/advisories/GHSA-7g9j-g5jg-3vv3)

![image](https://github.com/user-attachments/assets/e3ed12d6-588a-4568-8963-18284b7c115b)

This PR is to address this by updating the dependencies.
Did some unit testing with Github Actions without issues:

![image](https://github.com/user-attachments/assets/2b536887-6675-48af-9bdb-c2aea91fb007)
![image](https://github.com/user-attachments/assets/5920b2c0-b043-45c9-ab6e-eb73b7bffba3)

Logs of the unit test can be found here:
[logs_26199795131.zip](https://github.com/user-attachments/files/16312067/logs_26199795131.zip)

Please let me know if you need anything else or if I did anything wrong.
Otherwise, feel free to close if I misunderstood the situation.
